### PR TITLE
모달 UI 통합, 카테고리 버튼 선택, 배당금 수정 기능 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,122 @@
+# CLAUDE.md
+
+## 프로젝트 개요
+
+주식/자산 포트폴리오와 배당금을 관리하는 웹 애플리케이션.
+GitHub Pages로 `index.html` 단일 파일로 서비스한다.
+
+**개발 환경**: `stock-portfolio-dev` 저장소에서 개발 후, Firestore 경로(`dev_users` → `users`)만 변경하여 이 저장소에 반영한다.
+
+## 기술 스택
+
+- **프론트엔드**: Vanilla HTML/CSS/JavaScript (단일 `index.html` 파일)
+- **차트**: Chart.js + chartjs-plugin-datalabels (CDN)
+- **폰트**: IBM Plex Sans KR (Google Fonts)
+- **인증**: Firebase Authentication (Google 로그인)
+- **데이터베이스**: Firebase Firestore (무료 플랜, Spark)
+- **배포**: GitHub Pages
+- **Firebase SDK**: ES Module 방식으로 CDN에서 직접 import (v11.6.0)
+
+## 프로젝트 구조
+
+```
+stock-portfolio/
+├── index.html          # 메인 (유일한) 애플리케이션 파일
+├── README.md
+└── CLAUDE.md
+```
+
+## 아키텍처
+
+### 단일 파일 구조
+모든 HTML, CSS, JavaScript가 `index.html` 하나에 포함되어 있다. 별도의 빌드 도구나 번들러 없이 브라우저에서 직접 실행된다.
+
+### 스크립트 구성
+- **첫 번째 `<script type="module">`**: Firebase 초기화, 인증, Firestore CRUD (ES Module)
+- **두 번째 `<script>`**: 일반 스크립트. 포트폴리오 CRUD, 차트, 배당금, 테마, 로컬 저장/불러오기 등 모든 UI 로직
+- Firebase 모듈 스코프의 함수는 `window.*` 에 할당하여 HTML onclick에서 접근 가능하게 한다.
+
+### Firestore 데이터 구조
+```
+users/{uid}/charts/{chartName}
+  └── jsonData: string (JSON.stringify된 { items, dividendRecords, exchangeRate })
+```
+
+## 주요 기능
+
+### 자산 관리
+- 종목 추가/수정/삭제 (모달 UI, 이름/개수/가격/통화(KRW/USD)/카테고리/날짜)
+- 카테고리 버튼 토글 선택 + 신규 카테고리 추가/삭제
+- 환율 입력으로 USD → KRW 자동 환산
+- 카테고리별 필터링 (전체 선택/해제, 개별 토글)
+- 파이 차트로 카테고리별 자산 비율 시각화
+
+### 배당금 관리
+- 배당금 기록 추가/수정/삭제 (모달 UI)
+- 보유 종목 이름 자동완성 (datalist)
+- 배당금 내역 및 총 배당금 수익 요약 표시
+
+### 데이터 저장/불러오기
+- **로컬**: localStorage 저장/불러오기
+- **Firebase**: Google 로그인 후 Firestore에 차트 이름으로 저장/불러오기/삭제
+- **파일**: JSON/CSV 다운로드 및 업로드
+- **Firebase 차트별 내보내기**: 저장된 차트 목록에서 개별 JSON/CSV 다운로드
+
+### UI/테마
+- 다크모드/라이트모드 토글 (CSS Custom Properties 기반)
+- 테마 설정 localStorage에 자동 저장/복원
+- 전환 시 애니메이션 적용 (`transition`)
+
+## 데이터 모델
+
+### Item (자산)
+```javascript
+{
+  name: string,           // 종목 이름
+  amount: number,         // 개수 (소수점 가능)
+  price: number,          // 가격
+  currency: "KRW" | "USD",
+  categories: string[],   // 카테고리 목록 (예: ["토스", "배당"])
+  date: string            // YYYY-MM-DD
+}
+```
+
+### DividendRecord (배당금)
+```javascript
+{
+  id: string,             // 고유 ID (Date.now().toString(36))
+  stockName: string,      // 종목 이름
+  totalAmount: number,    // 배당금액
+  currency: "KRW" | "USD",
+  paymentDate: string,    // YYYY-MM-DD
+  note: string            // 메모 (선택)
+}
+```
+
+## CSV 포맷
+
+CSV는 두 섹션으로 구분된다. BOM(`\uFEFF`) 포함으로 한글 Excel 호환성을 보장한다.
+
+```
+[보유 자산 목록]
+이름,개수,가격,통화,카테고리,날짜
+
+[배당금 기록]
+종목이름,배당금액,통화,지급일,메모
+```
+
+- 카테고리는 `|`로 구분하여 큰따옴표로 감싼다 (예: `"토스|배당|리츠"`)
+- 메모는 큰따옴표로 감싸며 내부 `"`는 `""`로 이스케이프한다
+
+## 개발 가이드라인
+
+- 이 프로젝트는 `index.html` 단일 파일로 유지한다. 파일을 분리하지 않는다.
+- 외부 라이브러리는 CDN으로만 사용한다. npm/빌드 도구를 도입하지 않는다.
+- Firebase config 값은 프론트엔드 전용이므로 코드에 직접 포함되어 있다.
+- CSS는 CSS Custom Properties(변수)를 사용하여 다크모드를 지원한다. 새로운 스타일 추가 시 변수를 활용한다.
+- 한국어 UI를 기본으로 한다.
+- Firestore 경로는 `users/{uid}/charts/{chartName}`을 사용한다. (`stock-portfolio-dev`에서는 `dev_users`)
+
+## Git 컨벤션
+
+- 커밋 메시지: 한국어 사용

--- a/index.html
+++ b/index.html
@@ -8,31 +8,84 @@
   <style>
     @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+KR:wght@400;600&display=swap');
 
+    :root {
+      --bg-primary: #f8f9fa;
+      --bg-secondary: #fff;
+      --bg-form: #fff;
+      --text-primary: #333;
+      --text-secondary: #555;
+      --text-heading: #2c3e50;
+      --border-color: #ccc;
+      --shadow: rgba(0,0,0,0.1);
+      --dividend-record-bg: #f1f3f5;
+      --modal-bg: white;
+      --overlay-bg: rgba(0,0,0,0.5);
+      --cat-btn-bg: white;
+      --btn-primary: #3498db;
+      --btn-primary-hover: #2980b9;
+      --btn-danger: #e74c3c;
+      --btn-edit: #f39c12;
+      --btn-dividend: #8e44ad;
+      --btn-dividend-hover: #9b59b6;
+      --btn-save: #27ae60;
+      --file-label-bg: #3498db;
+      --chart-legend-color: #666;
+      --chart-title-color: #333;
+    }
+
+    [data-theme="dark"] {
+      --bg-primary: #1a1a2e;
+      --bg-secondary: #16213e;
+      --bg-form: #0f3460;
+      --text-primary: #e0e0e0;
+      --text-secondary: #b0b0b0;
+      --text-heading: #e0e0e0;
+      --border-color: #444;
+      --shadow: rgba(0,0,0,0.4);
+      --dividend-record-bg: #16213e;
+      --modal-bg: #1a1a2e;
+      --overlay-bg: rgba(0,0,0,0.7);
+      --cat-btn-bg: #16213e;
+      --btn-primary: #1a6fb5;
+      --btn-primary-hover: #155a94;
+      --btn-danger: #a93226;
+      --btn-edit: #b87a0a;
+      --btn-dividend: #6c3483;
+      --btn-dividend-hover: #7d3c98;
+      --btn-save: #1e8449;
+      --file-label-bg: #1a6fb5;
+      --chart-legend-color: #ccc;
+      --chart-title-color: #e0e0e0;
+    }
+
     body {
       font-family: 'IBM Plex Sans KR', sans-serif;
       padding: 20px;
-      background-color: #f8f9fa;
-      color: #333;
+      background-color: var(--bg-primary);
+      color: var(--text-primary);
       max-width: 700px;
       margin: 0 auto;
+      transition: background-color 0.3s, color 0.3s;
     }
-    h2, h3 { color: #2c3e50; font-weight: 600; }
+    h2, h3 { color: var(--text-heading); font-weight: 600; }
     input, select, button {
       margin: 5px;
       padding: 8px 10px;
       border-radius: 8px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--border-color);
       font-size: 14px;
       font-family: 'IBM Plex Sans KR', sans-serif;
+      background-color: var(--bg-secondary);
+      color: var(--text-primary);
     }
     button {
-      background-color: #3498db;
+      background-color: var(--btn-primary);
       color: white;
       cursor: pointer;
       font-weight: bold;
     }
-    button:hover { background-color: #2980b9; }
-    .item-list { margin-top: 15px; font-size: 14px; }
+    button:hover { background-color: var(--btn-primary-hover); }
+    .item-list, .dividend-list { margin-top: 15px; font-size: 14px; }
     #portfolioChartContainer {
       position: relative;
       width: 100%;
@@ -57,7 +110,7 @@
       padding: 8px 12px;
       font-weight: bold;
       border: 2px solid #27ae60;
-      background-color: white;
+      background-color: var(--cat-btn-bg);
       color: #27ae60;
       font-family: 'IBM Plex Sans KR', sans-serif;
     }
@@ -77,18 +130,28 @@
       margin-top: 5px;
     }
     .action-btn {
-      background-color: #e74c3c;
+      background-color: var(--btn-danger);
       margin-left: 5px;
+      padding: 4px 8px;
+      font-size: 12px;
     }
     .edit-btn {
-      background-color: #f39c12;
+      background-color: var(--btn-edit);
+      padding: 4px 8px;
+      font-size: 12px;
+    }
+    .btn-dividend {
+      background-color: var(--btn-dividend);
+    }
+    .btn-dividend:hover {
+      background-color: var(--btn-dividend-hover);
     }
     input[type="file"] {
       display: none;
     }
     .file-label {
       display: inline-block;
-      background-color: #3498db;
+      background-color: var(--file-label-bg);
       color: white;
       padding: 8px 12px;
       border-radius: 8px;
@@ -96,13 +159,118 @@
       font-weight: bold;
       margin: 5px;
     }
+    .modal-label {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text-secondary);
+      margin-bottom: 2px;
+    }
+    .modal-field {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+    .category-select-area {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 5px;
+      margin-top: 4px;
+    }
+    .category-select-area button {
+      min-height: 30px;
+      padding: 4px 10px;
+      font-size: 12px;
+      border: 2px solid #27ae60;
+      background-color: var(--cat-btn-bg);
+      color: #27ae60;
+    }
+    .category-select-area button.active {
+      background-color: #27ae60;
+      color: white;
+    }
+    .cat-delete-btn {
+      background: none !important;
+      border: none !important;
+      color: var(--text-secondary) !important;
+      font-size: 14px !important;
+      padding: 0 0 0 4px !important;
+      margin: 0 !important;
+      min-height: auto !important;
+      cursor: pointer;
+      opacity: 0.7;
+    }
+    .cat-delete-btn:hover {
+      opacity: 1;
+      color: var(--btn-danger) !important;
+    }
+    .new-cat-row {
+      display: flex;
+      gap: 5px;
+      margin-top: 4px;
+    }
+    .new-cat-row input {
+      flex: 1;
+      font-size: 13px;
+      padding: 4px 8px;
+    }
+    .new-cat-row button {
+      font-size: 12px;
+      padding: 4px 10px;
+    }
+    .theme-toggle {
+      background-color: #555;
+      font-size: 13px;
+      padding: 6px 12px;
+    }
+    .theme-toggle:hover {
+      background-color: #333;
+    }
+
+    /* 배당금 모달 스타일 */
+    .modal-overlay {
+      display: none;
+      position: fixed;
+      top: 0; left: 0; right: 0; bottom: 0;
+      background: var(--overlay-bg);
+      z-index: 1000;
+      justify-content: center;
+      align-items: center;
+    }
+    .modal-content {
+      background: var(--modal-bg);
+      padding: 20px;
+      border-radius: 12px;
+      width: 90%;
+      max-width: 450px;
+      box-shadow: 0 4px 15px var(--shadow);
+    }
+    .dividend-record {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 6px;
+      background: var(--dividend-record-bg);
+      padding: 8px 12px;
+      border-radius: 8px;
+      font-size: 13px;
+    }
+    .dividend-summary {
+      margin-top: 20px;
+      background: var(--bg-secondary);
+      padding: 15px;
+      border-radius: 8px;
+      box-shadow: 0 1px 3px var(--shadow);
+    }
   </style>
 </head>
 <body>
-  <h2>📊 웹 포트폴리오 차트</h2>
+  <div style="display:flex; justify-content:space-between; align-items:center;">
+    <h2>📊 웹 포트폴리오 차트</h2>
+    <button class="theme-toggle" onclick="toggleTheme()" id="themeToggleBtn">🌙 Dark</button>
+  </div>
   <button id="loginBtn" hidden class="bg-red-500 text-white px-4 py-2 rounded">Google 로그인</button>
   <button id="logoutBtn" hidden class="hidden text-sm underline text-gray-500">로그아웃</button>
-  <!-- <label>📌 차트 제목: </label> -->
+  
   <input hidden id="chartTitle" value="나의 포트폴리오" onchange="updateChart()" />
   <div class="flex items-center space-x-2">
     <input
@@ -122,17 +290,52 @@
     </button>
   </div>
   <br/>
-  <button onclick="toggleForm()">+ 종목 추가</button>
-  <div id="form" style="display:none;">
-    <input id="name" placeholder="종목 이름" />
-    <input id="amount" type="number" placeholder="개수" />
-    <input id="price" type="number" placeholder="가격" />
-    <select id="currency">
-      <option value="KRW">원</option>
-      <option value="USD">달러</option>
-    </select>
-    <input id="category" placeholder="카테고리 (쉼표로 구분)" />
-    <button onclick="submitItem()">확인</button>
+  <div style="display:flex; gap:5px; flex-wrap:wrap;">
+    <button onclick="openStockModal()">+ 종목 추가</button>
+    <button class="btn-dividend" onclick="openDividendModal()">+ 배당금 추가</button>
+  </div>
+
+  <div class="modal-overlay" id="stockModal">
+    <div class="modal-content">
+      <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:15px;">
+        <h3 id="stockModalTitle">📌 종목 추가</h3>
+        <button onclick="closeStockModal()" style="background:transparent; color:#999; border:none; font-size:20px;">✕</button>
+      </div>
+      <div style="display:flex; flex-direction:column; gap:8px;">
+        <div class="modal-field">
+          <label class="modal-label">종목 이름</label>
+          <input id="name" placeholder="종목 이름" />
+        </div>
+        <div class="modal-field">
+          <label class="modal-label">개수</label>
+          <input id="amount" type="number" placeholder="개수" />
+        </div>
+        <div class="modal-field">
+          <label class="modal-label">가격</label>
+          <input id="price" type="number" placeholder="가격" />
+        </div>
+        <div class="modal-field">
+          <label class="modal-label">통화</label>
+          <select id="currency">
+            <option value="KRW">원</option>
+            <option value="USD">달러</option>
+          </select>
+        </div>
+        <div class="modal-field">
+          <label class="modal-label">카테고리</label>
+          <div class="category-select-area" id="modalCategoryButtons"></div>
+          <div class="new-cat-row">
+            <input id="newCategoryInput" placeholder="새 카테고리 입력" />
+            <button onclick="addNewCategory()">추가</button>
+          </div>
+        </div>
+        <div class="modal-field">
+          <label class="modal-label">날짜</label>
+          <input id="stockDate" type="date" />
+        </div>
+        <button id="stockSubmitBtn" onclick="submitItem()">추가하기</button>
+      </div>
+    </div>
   </div>
 
   <div style="margin-top:15px;">
@@ -151,37 +354,73 @@
   <div class="total" id="totalAmount"></div>
   <div class="totals-breakdown" id="categoryTotals"></div>
 
+  <div id="dividendListContainer"></div>
+  <div id="dividendSummaryContainer"></div>
+
   <h3>📂 데이터 저장 및 불러오기</h3>
   <button onclick="saveData()">💾 저장 (로컬)</button>
   <button onclick="loadData()">📂 불러오기 (로컬)</button>
   <button onclick="downloadCSV()">⬇️ CSV 다운로드</button>
   <button onclick="downloadJSON()">⬇️ JSON 다운로드</button>
-  <label for="fileUpload" class="file-label">📁 파일 업로드</label>
-  <input type="file" id="fileUpload" onchange="uploadFile(event)" />
+  <label for="fileUpload" class="file-label">📁 JSON 업로드</label>
+  <input type="file" id="fileUpload" accept=".json" onchange="uploadFile(event)" />
+  <label for="csvUpload" class="file-label">📁 CSV 업로드</label>
+  <input type="file" id="csvUpload" accept=".csv" onchange="uploadCSVFile(event)" />
 
-  <!-- <button id="firebaseSaveBtn" hidden class="hidden text-sm underline text-gray-500">계정에 저장</button> -->
   <h3>📊 Google 계정에 저장된 차트 목록</h3>
-  <div id="chartList">
-    <!-- charts 리스트가 여기에 동적으로 추가될거야 -->
+  <div id="chartList"></div>
+
+  <div class="modal-overlay" id="dividendModal">
+    <div class="modal-content">
+      <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:15px;">
+        <h3 id="dividendModalTitle">💰 배당금 추가</h3>
+        <button onclick="closeDividendModal()" style="background:transparent; color:#999; border:none; font-size:20px;">✕</button>
+      </div>
+      <div style="display:flex; flex-direction:column; gap:8px;">
+        <div class="modal-field">
+          <label class="modal-label">종목이름</label>
+          <input id="divStockName" list="divStockList" placeholder="직접입력 또는 선택" />
+          <datalist id="divStockList"></datalist>
+        </div>
+        <div class="modal-field">
+          <label class="modal-label">배당금액 / 통화</label>
+          <div style="display:flex; gap:5px;">
+            <input id="divTotalAmount" type="number" step="0.01" placeholder="배당금액" style="flex:1" />
+            <select id="divCurrency" style="width: 80px;">
+              <option value="KRW">KRW</option>
+              <option value="USD">USD</option>
+            </select>
+          </div>
+        </div>
+        <div class="modal-field">
+          <label class="modal-label">지급일</label>
+          <input id="divDate" type="date" />
+        </div>
+        <div class="modal-field">
+          <label class="modal-label">메모 (선택)</label>
+          <input id="divNote" placeholder="메모" />
+        </div>
+        <button class="btn-dividend" id="dividendSubmitBtn" onclick="addDividendRecord()">추가하기</button>
+      </div>
+    </div>
   </div>
 
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.0/firebase-app.js";
     import { getAuth, GoogleAuthProvider, signInWithPopup, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/11.6.0/firebase-auth.js";
     import { getFirestore, doc, setDoc, getDoc, collection, getDocs, deleteDoc } from 'https://www.gstatic.com/firebasejs/11.6.0/firebase-firestore.js';
-    import { getDatabase, ref, set, get, onValue } from "https://www.gstatic.com/firebasejs/11.6.0/firebase-database.js";
 
     const firebaseConfig = {
       apiKey: "AIzaSyC1-dNvQQbb4B5j6N5hZCI4dT8yTVu8y8o",
       authDomain: "my-portfolio-app-ae0e6.firebaseapp.com",
+      databaseURL: "https://my-portfolio-app-ae0e6-default-rtdb.asia-southeast1.firebasedatabase.app",
       projectId: "my-portfolio-app-ae0e6",
       storageBucket: "my-portfolio-app-ae0e6.firebasestorage.app",
       messagingSenderId: "297732155840",
-      appId: "1:297732155840:web:5455116e2a03cfcccc0025",
-      measurementId: "G-4N0N8Q981S"
+      appId: "1:297732155840:web:e7b288878e27f69fcc0025",
+      measurementId: "G-HXMCWTC9PS"
     };
 
-    // Initialize Firebase
     const app = initializeApp(firebaseConfig);
     const auth = getAuth(app);
     const db = getFirestore(app);
@@ -196,7 +435,6 @@
         const result = await signInWithPopup(auth, provider);
         currentUser = result.user;
         console.log('✅ 로그인:', currentUser.email);
-        // loadUserStocks();
       } catch (err) {
         console.error('❌ 로그인 오류:', err.message);
       }
@@ -214,24 +452,17 @@
       const chartNameInput = document.getElementById("chartNameInput");
       if (user) {
         currentUser = user;
-        // loginBtn.setAttribute("hidden", "hidden");
-        // logoutBtn.removeAttribute("hidden");
         loginBtn.style.display = 'none';
         logoutBtn.style.display = 'inline-block';
         firebaseSaveBtn.style.display = 'inline-block';
         chartNameInput.style.display = 'inline-block';
-
-        loadChartList(); // ✅ 로그인하면 charts 목록 불러오기
+        loadChartList();
       } else {
-        // loginBtn.removeAttribute("hidden");
-        // logoutBtn.setAttribute("hidden", "hidden");
         loginBtn.style.display = 'inline-block';
         logoutBtn.style.display = 'none';
         firebaseSaveBtn.style.display = 'none';
         chartNameInput.style.display = 'none';
-
-        const chartListDiv = document.getElementById('chartList');
-        chartListDiv.innerHTML = ''; // 로그아웃 시 charts 목록 지우기
+        document.getElementById('chartList').innerHTML = '';
       }
     });
 
@@ -245,112 +476,228 @@
         return;
       }
       await saveToFirebase(chartName);
-      chartNameInput.value = ''; // 저장 후 입력창 비우기
+      chartNameInput.value = '';
     });
 
     async function saveToFirebase(chartName) {
       const data = {
         items,
+        dividendRecords, // 배당금 데이터도 저장
         exchangeRate: getExchangeRate()
       };
-      console.log(`현재 사용자: ${currentUser.uid}`);
       await setDoc(doc(db, 'users', currentUser.uid, 'charts', chartName), {
         jsonData: JSON.stringify(data)
       });
       alert(`'${chartName}' 이름으로 저장되었습니다.`);
-      loadChartList(); // 차트 목록 새로고침
+      loadChartList();
     }
 
     async function loadChartList() {
       const chartListDiv = document.getElementById('chartList');
-      chartListDiv.innerHTML = ''; // 리스트 초기화
-
+      chartListDiv.innerHTML = '';
       const chartsRef = collection(db, 'users', currentUser.uid, 'charts');
       const snapshot = await getDocs(chartsRef);
 
       snapshot.forEach(docSnap => {
         const chartName = docSnap.id;
-
         const div = document.createElement('div');
         div.className = "flex items-center space-x-4";
+        div.style.cssText = "margin-bottom:5px; display:flex; flex-wrap:wrap; align-items:center; gap:3px;";
 
-        const nameSpan = document.createElement('span');
-        nameSpan.textContent = chartName;
-        nameSpan.className = "text-gray-700";
-
-        const loadButton = document.createElement('button');
-        loadButton.textContent = '불러오기';
-        loadButton.className = "bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600 text-sm";
-        loadButton.addEventListener('click', () => loadChart(chartName));
-
-        const deleteButton = document.createElement('button');
-        deleteButton.textContent = '삭제하기';
-        deleteButton.className = "bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600 text-sm";
-        deleteButton.addEventListener('click', (event) => {
-          const chartDiv = event.target.closest('div'); // 삭제 버튼의 부모 div 찾기
-          deleteChart(chartDiv, chartName);
-        });
-
-        div.appendChild(nameSpan);
-        div.appendChild(loadButton);
-        div.appendChild(deleteButton);
+        div.innerHTML = `
+          <span style="display:inline-block; width:150px; font-weight:bold;">${chartName}</span>
+          <button class="action-btn" style="background:var(--btn-save)" onclick="window.loadChartClick('${chartName}')">불러오기</button>
+          <button class="action-btn" style="background:var(--btn-primary)" onclick="window.downloadChartJSON('${chartName}')">JSON</button>
+          <button class="action-btn" style="background:var(--btn-primary)" onclick="window.downloadChartCSV('${chartName}')">CSV</button>
+          <button class="action-btn" onclick="window.deleteChartClick(this, '${chartName}')">삭제하기</button>
+        `;
         chartListDiv.appendChild(div);
       });
 
       if (snapshot.empty) {
-        chartListDiv.innerHTML = '<p class="text-gray-500">저장된 차트가 없습니다.</p>';
+        chartListDiv.innerHTML = '<p style="color:#888;">저장된 차트가 없습니다.</p>';
       }
     }
 
-    async function loadChart(chartName) {
+    // 모듈 스코프 함수를 전역으로 노출 (HTML onclick에서 접근 가능하도록)
+    window.loadChartClick = async (chartName) => {
       const chartDocRef = doc(db, 'users', currentUser.uid, 'charts', chartName);
       const chartDoc = await getDoc(chartDocRef);
-
       if (chartDoc.exists()) {
         const data = JSON.parse(chartDoc.data().jsonData);
-
-        items = data.items || [];
-        document.getElementById('exchangeRate').value = data.exchangeRate || 1300;
-        updateAll();
+        window.loadDataFromObject(data);
       } else {
         alert('차트를 찾을 수 없습니다.');
       }
-    }
+    };
 
-    async function deleteChart(selfElement, chartName) {
+    window.downloadChartJSON = async (chartName) => {
       const chartDocRef = doc(db, 'users', currentUser.uid, 'charts', chartName);
       const chartDoc = await getDoc(chartDocRef);
+      if (!chartDoc.exists()) { alert('차트를 찾을 수 없습니다.'); return; }
+      const data = JSON.parse(chartDoc.data().jsonData);
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url; a.download = `${chartName}.json`; a.click();
+      URL.revokeObjectURL(url);
+    };
 
-      if (chartDoc.exists()) {
+    window.downloadChartCSV = async (chartName) => {
+      const chartDocRef = doc(db, 'users', currentUser.uid, 'charts', chartName);
+      const chartDoc = await getDoc(chartDocRef);
+      if (!chartDoc.exists()) { alert('차트를 찾을 수 없습니다.'); return; }
+      const data = JSON.parse(chartDoc.data().jsonData);
+      const chartItems = data.items || [];
+      const chartDividends = data.dividendRecords || [];
+
+      let csvContent = "\uFEFF";
+      csvContent += "[보유 자산 목록]\n";
+      csvContent += "이름,개수,가격,통화,카테고리,날짜\n";
+      csvContent += chartItems.map(i =>
+        `${i.name},${i.amount},${i.price},${i.currency},"${i.categories.join('|')}",${i.date}`
+      ).join('\n');
+      csvContent += "\n\n";
+      csvContent += "[배당금 기록]\n";
+      csvContent += "종목이름,배당금액,통화,지급일,메모\n";
+      if (chartDividends.length > 0) {
+        csvContent += chartDividends.map(d => {
+          const safeNote = d.note ? d.note.replace(/"/g, '""') : '';
+          return `${d.stockName},${d.totalAmount},${d.currency},${d.paymentDate},"${safeNote}"`;
+        }).join('\n');
+      }
+
+      const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url; a.download = `${chartName}.csv`; a.click();
+      URL.revokeObjectURL(url);
+    };
+
+    window.deleteChartClick = async (selfElement, chartName) => {
+        if(!confirm(`'${chartName}' 차트를 삭제하시겠습니까?`)) return;
+        const chartDocRef = doc(db, 'users', currentUser.uid, 'charts', chartName);
         try {
-          // Firebase에서 차트 삭제
           await deleteDoc(chartDocRef);
           alert("삭제 완료!");
-          
-          // 화면에서 해당 차트 요소 지우기
-          selfElement.remove();
+          selfElement.parentElement.remove();
         } catch (error) {
           console.error("차트 삭제 오류:", error);
         }
-
-        // 차트 삭제 후 전체 업데이트
-        updateAll();
-      } else {
-        alert('차트를 찾을 수 없습니다.');
-      }
-    }
+    };
   </script>
 
   <script>
     let items = [];
+    let dividendRecords = [];
     let portfolioChart = null;
     let selectedCategories = new Set();
     let editingIndex = null;
 
-    function toggleForm() {
-      const form = document.getElementById('form');
-      form.style.display = form.style.display === 'none' ? 'block' : 'none';
-      if (form.style.display === 'none') clearForm();
+    // --- 테마 토글 ---
+    function toggleTheme() {
+      const html = document.documentElement;
+      const btn = document.getElementById('themeToggleBtn');
+      if (html.getAttribute('data-theme') === 'dark') {
+        html.removeAttribute('data-theme');
+        btn.textContent = '🌙 Dark';
+        localStorage.setItem('theme', 'light');
+      } else {
+        html.setAttribute('data-theme', 'dark');
+        btn.textContent = '☀️ Light';
+        localStorage.setItem('theme', 'dark');
+      }
+      updateChart();
+    }
+
+    // 저장된 테마 복원
+    (function() {
+      const saved = localStorage.getItem('theme');
+      if (saved === 'dark') {
+        document.documentElement.setAttribute('data-theme', 'dark');
+        document.getElementById('themeToggleBtn').textContent = '☀️ Light';
+      }
+    })();
+
+    // --- 기본 기능 ---
+
+    let modalSelectedCategories = new Set();
+    let modalNewCategories = new Set();
+
+    function getAllCategories() {
+      return [...new Set(items.flatMap(i => i.categories))];
+    }
+
+    function renderModalCategoryButtons() {
+      const container = document.getElementById('modalCategoryButtons');
+      const existingCats = getAllCategories();
+      const allCats = [...new Set([...existingCats, ...modalSelectedCategories])];
+      container.innerHTML = allCats.map(cat => {
+        const isNew = modalNewCategories.has(cat);
+        const isActive = modalSelectedCategories.has(cat);
+        const deleteBtn = isNew ? `<span class="cat-delete-btn" onclick="event.stopPropagation(); removeNewCategory('${cat}')">✕</span>` : '';
+        return `<button type="button" class="${isActive ? 'active' : ''}" onclick="toggleModalCategory('${cat}')">${cat}${deleteBtn}</button>`;
+      }).join('');
+    }
+
+    function toggleModalCategory(cat) {
+      if (modalSelectedCategories.has(cat)) modalSelectedCategories.delete(cat);
+      else modalSelectedCategories.add(cat);
+      renderModalCategoryButtons();
+    }
+
+    function addNewCategory() {
+      const input = document.getElementById('newCategoryInput');
+      const cat = input.value.trim();
+      if (!cat) return;
+      modalSelectedCategories.add(cat);
+      if (!getAllCategories().includes(cat)) {
+        modalNewCategories.add(cat);
+      }
+      input.value = '';
+      renderModalCategoryButtons();
+    }
+
+    function removeNewCategory(cat) {
+      modalNewCategories.delete(cat);
+      modalSelectedCategories.delete(cat);
+      renderModalCategoryButtons();
+    }
+
+    function openStockModal(index) {
+      const title = document.getElementById('stockModalTitle');
+      const btn = document.getElementById('stockSubmitBtn');
+      document.getElementById('name').value = '';
+      document.getElementById('amount').value = '';
+      document.getElementById('price').value = '';
+      document.getElementById('currency').value = 'KRW';
+      document.getElementById('stockDate').value = new Date().toISOString().split('T')[0];
+      modalSelectedCategories.clear();
+      modalNewCategories.clear();
+      editingIndex = null;
+
+      if (index !== undefined) {
+        const item = items[index];
+        document.getElementById('name').value = item.name;
+        document.getElementById('amount').value = item.amount;
+        document.getElementById('price').value = item.price;
+        document.getElementById('currency').value = item.currency;
+        document.getElementById('stockDate').value = item.date;
+        item.categories.forEach(c => modalSelectedCategories.add(c));
+        editingIndex = index;
+        title.textContent = '📌 종목 수정';
+        btn.textContent = '수정하기';
+      } else {
+        title.textContent = '📌 종목 추가';
+        btn.textContent = '추가하기';
+      }
+      renderModalCategoryButtons();
+      document.getElementById('stockModal').style.display = 'flex';
+    }
+
+    function closeStockModal() {
+      document.getElementById('stockModal').style.display = 'none';
+      editingIndex = null;
     }
 
     function submitItem() {
@@ -358,36 +705,26 @@
       const amount = parseFloat(document.getElementById('amount').value);
       const price = parseFloat(document.getElementById('price').value);
       const currency = document.getElementById('currency').value;
-      const categories = document.getElementById('category').value.split(',').map(c => c.trim()).filter(c => c);
-      const date = new Date().toISOString().split('T')[0];
+      const categories = [...modalSelectedCategories];
+      const date = document.getElementById('stockDate').value;
 
       if (!name || isNaN(amount) || isNaN(price)) {
         alert('이름, 개수, 가격을 정확히 입력해주세요.');
         return;
       }
-
       const item = { name, amount, price, currency, categories, date };
-
       if (editingIndex !== null) {
         items[editingIndex] = item;
         editingIndex = null;
       } else {
         items.push(item);
       }
-
-      clearForm();
+      closeStockModal();
       updateAll();
     }
 
     function editItem(index) {
-      const item = items[index];
-      document.getElementById('name').value = item.name;
-      document.getElementById('amount').value = item.amount;
-      document.getElementById('price').value = item.price;
-      document.getElementById('currency').value = item.currency;
-      document.getElementById('category').value = item.categories.join(', ');
-      editingIndex = index;
-      document.getElementById('form').style.display = 'block';
+      openStockModal(index);
     }
 
     function deleteItem(index) {
@@ -395,15 +732,6 @@
         items.splice(index, 1);
         updateAll();
       }
-    }
-
-    function clearForm() {
-      document.getElementById('name').value = '';
-      document.getElementById('amount').value = '';
-      document.getElementById('price').value = '';
-      document.getElementById('currency').value = 'KRW';
-      document.getElementById('category').value = '';
-      editingIndex = null;
     }
 
     function getExchangeRate() {
@@ -420,15 +748,17 @@
       updateCategoryButtons();
       updateChart();
       updateTotal();
+      updateDividendList();
+      updateDividendSummary();
     }
 
     function updateList() {
       const list = document.getElementById('itemList');
       list.innerHTML = items.map((i, idx) => `
-        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; background: #fff; padding: 10px; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1);">
+        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; background: var(--bg-secondary); padding: 10px; border-radius: 8px; box-shadow: 0 1px 3px var(--shadow);">
           <div style="text-align: left;">
             <div>📌 ${i.name} - ${i.amount}개 x ${i.price}${i.currency} = ${getTotalValue(i).toLocaleString()}원</div>
-            <div style="margin-top: 4px; font-size: 13px; color: #555;">
+            <div style="margin-top: 4px; font-size: 13px; color: var(--text-secondary);">
               [${i.categories.join(', ')} | ${i.date}]
             </div>
           </div>
@@ -440,68 +770,181 @@
       `).join('');
     }
 
+    // --- 배당금 관련 기능 ---
+
+    let editingDividendId = null;
+
+    function openDividendModal(id) {
+      const datalist = document.getElementById('divStockList');
+      datalist.innerHTML = items.map(item => `<option value="${item.name}">`).join('');
+      const title = document.getElementById('dividendModalTitle');
+      const btn = document.getElementById('dividendSubmitBtn');
+
+      document.getElementById('divStockName').value = '';
+      document.getElementById('divTotalAmount').value = '';
+      document.getElementById('divCurrency').value = 'KRW';
+      document.getElementById('divDate').value = new Date().toISOString().split('T')[0];
+      document.getElementById('divNote').value = '';
+      editingDividendId = null;
+
+      if (id !== undefined) {
+        const record = dividendRecords.find(d => d.id === id);
+        if (record) {
+          document.getElementById('divStockName').value = record.stockName;
+          document.getElementById('divTotalAmount').value = record.totalAmount;
+          document.getElementById('divCurrency').value = record.currency;
+          document.getElementById('divDate').value = record.paymentDate;
+          document.getElementById('divNote').value = record.note || '';
+          editingDividendId = id;
+          title.textContent = '💰 배당금 수정';
+          btn.textContent = '수정하기';
+        }
+      } else {
+        title.textContent = '💰 배당금 추가';
+        btn.textContent = '추가하기';
+      }
+      document.getElementById('dividendModal').style.display = 'flex';
+    }
+
+    function closeDividendModal() {
+      document.getElementById('dividendModal').style.display = 'none';
+      editingDividendId = null;
+    }
+
+    function addDividendRecord() {
+      const stockName = document.getElementById('divStockName').value.trim();
+      const totalAmount = parseFloat(document.getElementById('divTotalAmount').value);
+      const currency = document.getElementById('divCurrency').value;
+      const paymentDate = document.getElementById('divDate').value;
+      const note = document.getElementById('divNote').value.trim();
+
+      if (!stockName || isNaN(totalAmount) || !paymentDate) {
+        alert('필수 정보를 입력해주세요 (종목명, 금액, 날짜)');
+        return;
+      }
+
+      if (editingDividendId) {
+        const idx = dividendRecords.findIndex(d => d.id === editingDividendId);
+        if (idx !== -1) {
+          dividendRecords[idx] = { ...dividendRecords[idx], stockName, totalAmount, currency, paymentDate, note };
+        }
+      } else {
+        dividendRecords.push({
+          id: Date.now().toString(36),
+          stockName,
+          totalAmount,
+          currency,
+          paymentDate,
+          note
+        });
+      }
+
+      closeDividendModal();
+      updateAll();
+    }
+
+    function editDividend(id) {
+      openDividendModal(id);
+    }
+
+    function deleteDividend(id) {
+        if(confirm('삭제하시겠습니까?')) {
+            dividendRecords = dividendRecords.filter(d => d.id !== id);
+            updateAll();
+        }
+    }
+
+    function updateDividendList() {
+        const container = document.getElementById('dividendListContainer');
+        const rate = getExchangeRate();
+        
+        if (dividendRecords.length === 0) {
+            container.innerHTML = '';
+            return;
+        }
+
+        const sorted = [...dividendRecords].sort((a, b) => b.paymentDate.localeCompare(a.paymentDate));
+
+        container.innerHTML = `
+            <h3>💰 배당금 내역 (${sorted.length}건)</h3>
+            <div class="dividend-list">
+                ${sorted.map(d => {
+                    const krw = d.currency === 'USD' ? d.totalAmount * rate : d.totalAmount;
+                    return `
+                        <div class="dividend-record">
+                            <div>
+                                <strong>${d.stockName}</strong> 
+                                <span style="color:#8e44ad; font-weight:bold;">+${d.currency==='USD'?'$':''}${d.totalAmount.toLocaleString()}${d.currency==='KRW'?'원':''}</span>
+                                <span style="color:#888; font-size:12px;">(${krw.toLocaleString()}원)</span>
+                                <br/>
+                                <span style="font-size:12px; color:#555;">${d.paymentDate} ${d.note ? ' · ' + d.note : ''}</span>
+                            </div>
+                            <div>
+                                <button class="edit-btn" onclick="editDividend('${d.id}')">✏️</button>
+                                <button class="action-btn" onclick="deleteDividend('${d.id}')">🗑️</button>
+                            </div>
+                        </div>
+                    `;
+                }).join('')}
+            </div>
+        `;
+    }
+
+    function updateDividendSummary() {
+        const container = document.getElementById('dividendSummaryContainer');
+        if (dividendRecords.length === 0) {
+            container.innerHTML = '';
+            return;
+        }
+        const rate = getExchangeRate();
+        const total = dividendRecords.reduce((sum, d) => sum + (d.currency === 'USD' ? d.totalAmount * rate : d.totalAmount), 0);
+        
+        container.innerHTML = `
+            <div class="dividend-summary" style="text-align:center;">
+                <span style="font-size:14px; color:#555;">총 배당금 수익</span><br/>
+                <span style="font-size:20px; font-weight:bold; color:#8e44ad;">${total.toLocaleString()} 원</span>
+            </div>
+        `;
+    }
+
+
+    // --- 차트 및 카테고리 기능 ---
+
     function updateCategoryButtons() {
       const container = document.getElementById('categoryButtons');
       const allCategories = [...new Set(items.flatMap(i => i.categories))];
-      
       if (allCategories.length === 0) {
         container.innerHTML = '';
         return;
       }
-
-      let html = '';
-
-      // 전체 버튼 텍스트: 전체 선택 또는 전체 해제
       const isAllSelected = selectedCategories.size === allCategories.length;
       const allButtonText = isAllSelected ? '전체 해제' : '전체 선택';
 
-
-      // 전체 선택/해제 버튼 추가
-      html += `
-        <button onclick="toggleAllCategories()" 
-          class="${isAllSelected || selectedCategories.size === 0 ? 'active' : ''}">
-          ${allButtonText}
-        </button>
-      `;
-
-      html += allCategories.map(cat => `
-        <button onclick="toggleCategory('${cat}')" class="${selectedCategories.has(cat) ? 'active' : ''}">
-          ${cat}
-        </button>
-      `).join('');
-
+      let html = `<button onclick="toggleAllCategories()" class="${isAllSelected || selectedCategories.size === 0 ? 'active' : ''}">${allButtonText}</button>`;
+      html += allCategories.map(cat => `<button onclick="toggleCategory('${cat}')" class="${selectedCategories.has(cat) ? 'active' : ''}">${cat}</button>`).join('');
       container.innerHTML = html;
     }
 
     function toggleAllCategories() {
       const allCategories = [...new Set(items.flatMap(i => i.categories))];
-
-      if (selectedCategories.size === allCategories.length) {
-        selectedCategories.clear();
-      } else {
-        selectedCategories = new Set(allCategories);
-      }
-
-      updateCategoryButtons();
-      updateChart();
-      updateTotal();
+      if (selectedCategories.size === allCategories.length) selectedCategories.clear();
+      else selectedCategories = new Set(allCategories);
+      updateCategoryButtons(); updateChart(); updateTotal();
     }
 
     function toggleCategory(cat) {
-      if (selectedCategories.has(cat)) {
-        selectedCategories.delete(cat);
-      } else {
-        selectedCategories.add(cat);
-      }
-      updateCategoryButtons();
-      updateChart();
-      updateTotal();
+      if (selectedCategories.has(cat)) selectedCategories.delete(cat);
+      else selectedCategories.add(cat);
+      updateCategoryButtons(); updateChart(); updateTotal();
+    }
+
+    function isDarkMode() {
+      return document.documentElement.getAttribute('data-theme') === 'dark';
     }
 
     function updateChart() {
       const ctx = document.getElementById('portfolioChart').getContext('2d');
       const categorySums = {};
-
       items.forEach(item => {
         const value = getTotalValue(item);
         item.categories.forEach(cat => {
@@ -513,8 +956,12 @@
 
       const labels = Object.keys(categorySums);
       const values = Object.values(categorySums);
-
       if (portfolioChart) portfolioChart.destroy();
+
+      const dark = isDarkMode();
+      const legendColor = dark ? '#ccc' : '#666';
+      const titleColor = dark ? '#e0e0e0' : '#333';
+      const borderColor = dark ? '#1a1a2e' : '#fff';
 
       portfolioChart = new Chart(ctx, {
         type: 'pie',
@@ -522,9 +969,9 @@
           labels,
           datasets: [{
             data: values,
-            backgroundColor: [
-              '#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF', '#FF9F40'
-            ]
+            backgroundColor: ['#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF', '#FF9F40'],
+            borderColor: borderColor,
+            borderWidth: 2
           }]
         },
         options: {
@@ -533,18 +980,18 @@
             datalabels: {
               formatter: (value, context) => {
                 const sum = context.chart._metasets[0].total;
-                const percentage = ((value / sum) * 100).toFixed(1) + '%';
-                return percentage;
+                return ((value / sum) * 100).toFixed(1) + '%';
               },
-              color: '#fff',
-              font: {
-                weight: 'bold'
-              }
+              color: '#fff', font: { weight: 'bold' }
             },
-            legend: { position: 'bottom' },
+            legend: {
+              position: 'bottom',
+              labels: { color: legendColor }
+            },
             title: {
               display: true,
-              text: document.getElementById('chartTitle').value
+              text: document.getElementById('chartTitle').value,
+              color: titleColor
             }
           }
         },
@@ -563,44 +1010,78 @@
       totalDiv.textContent = `총합: ${sum.toLocaleString()} 원`;
     }
 
+    // --- 저장 및 불러오기 (로컬/파일) ---
+
+    // 데이터를 전역 객체에 반영하는 함수 (Firebase load 등에서 사용)
+    window.loadDataFromObject = (data) => {
+        items = data.items || [];
+        dividendRecords = data.dividendRecords || [];
+        document.getElementById('exchangeRate').value = data.exchangeRate || 1300;
+        updateAll();
+        // alert('데이터를 성공적으로 불러왔습니다!');
+    };
+
     function saveData() {
-      const data = {
-        items,
-        exchangeRate: getExchangeRate()
-      };
-      console.log(JSON.stringify(data));
+      const data = { items, dividendRecords, exchangeRate: getExchangeRate() };
       localStorage.setItem('portfolioData', JSON.stringify(data));
       alert('저장되었습니다.');
     }
 
     function loadData() {
       const data = localStorage.getItem('portfolioData');
-      if (data) {
-        const parsed = JSON.parse(data);
-        items = parsed.items || [];
-        document.getElementById('exchangeRate').value = parsed.exchangeRate || 1300;
-        updateAll();
-        alert('불러오기 완료!');
-      } else {
-        alert('저장된 데이터가 없습니다.');
-      }
+      if (data) window.loadDataFromObject(JSON.parse(data));
+      else alert('저장된 데이터가 없습니다.');
     }
 
     function downloadJSON() {
-      const blob = new Blob([JSON.stringify({ items, exchangeRate: getExchangeRate() }, null, 2)], { type: 'application/json' });
+      const blob = new Blob([JSON.stringify({ items, dividendRecords, exchangeRate: getExchangeRate() }, null, 2)], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
-      console.log(blob)
-      console.log(url)
       a.href = url;
       a.download = 'portfolio.json';
       a.click();
     }
 
+    function uploadFile(event) {
+      const file = event.target.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = function(e) {
+        try {
+          window.loadDataFromObject(JSON.parse(e.target.result));
+        } catch (e) { alert('JSON 형식이 올바르지 않습니다.'); }
+      };
+      reader.readAsText(file);
+      event.target.value = '';
+    }
+
+    // --- CSV 다운로드 및 업로드 핵심 로직 ---
+
     function downloadCSV() {
-      const header = '이름,개수,가격,통화,카테고리,날짜\n';
-      const rows = items.map(i => `${i.name},${i.amount},${i.price},${i.currency},"${i.categories.join('|')}",${i.date}`).join('\n');
-      const blob = new Blob([header + rows], { type: 'text/csv' });
+      // 1. BOM 추가 (엑셀 한글 깨짐 방지)
+      let csvContent = "\uFEFF";
+
+      // 2. 자산 섹션 작성
+      csvContent += "[보유 자산 목록]\n";
+      csvContent += "이름,개수,가격,통화,카테고리,날짜\n";
+      csvContent += items.map(i => 
+        `${i.name},${i.amount},${i.price},${i.currency},"${i.categories.join('|')}",${i.date}`
+      ).join('\n');
+      
+      csvContent += "\n\n"; // 섹션 구분
+
+      // 3. 배당금 섹션 작성
+      csvContent += "[배당금 기록]\n";
+      csvContent += "종목이름,배당금액,통화,지급일,메모\n";
+      
+      if (dividendRecords.length > 0) {
+        csvContent += dividendRecords.map(d => {
+            const safeNote = d.note ? d.note.replace(/"/g, '""') : '';
+            return `${d.stockName},${d.totalAmount},${d.currency},${d.paymentDate},"${safeNote}"`;
+        }).join('\n');
+      }
+
+      const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
@@ -608,24 +1089,93 @@
       a.click();
     }
 
-    function uploadFile(event) {
+    function uploadCSVFile(event) {
       const file = event.target.files[0];
       if (!file) return;
 
       const reader = new FileReader();
       reader.onload = function(e) {
         try {
-          const data = JSON.parse(e.target.result);
-          items = data.items || [];
-          document.getElementById('exchangeRate').value = data.exchangeRate || 1300;
-          updateAll();
-          alert('파일 불러오기 완료!');
-        } catch (e) {
-          alert('JSON 형식이 올바르지 않습니다.');
+          const text = e.target.result;
+          const lines = text.split('\n');
+          
+          let currentSection = 'items'; // 기본값은 자산 목록 (헤더 없는 구버전 파일 호환)
+          const newItems = [];
+          const newDividends = [];
+
+          for (let i = 0; i < lines.length; i++) {
+            const line = lines[i].trim();
+            if (!line) continue;
+
+            // 섹션 감지
+            if (line.includes('[보유 자산 목록]')) { currentSection = 'items'; continue; }
+            if (line.includes('[배당금 기록]')) { currentSection = 'dividends'; continue; }
+            
+            // 헤더 건너뛰기
+            if (line.startsWith('이름,개수') || line.startsWith('Name,Amount') || line.startsWith('종목이름,배당금액')) continue;
+
+            if (currentSection === 'items') {
+                // 자산 데이터 파싱
+                const match = line.match(/^(.*?),([\d.]+),([\d.]+),(KRW|USD),"([^"]*)",(\d{4}-\d{2}-\d{2})$/);
+                if (match) {
+                    const [, name, amount, price, currency, categories, date] = match;
+                    newItems.push({
+                        name: name.trim(),
+                        amount: parseFloat(amount),
+                        price: parseFloat(price),
+                        currency: currency.trim(),
+                        categories: categories.split('|').map(c => c.trim()),
+                        date: date.trim()
+                    });
+                }
+            } else if (currentSection === 'dividends') {
+                // 배당금 데이터 파싱: 종목이름,금액,통화,날짜,"메모"
+                // 간단한 파싱 (메모에 콤마가 있을 경우 정규식 필요하지만 여기선 간단히 split 처리 보완)
+                // 정규식: 이름, 금액, 통화, 날짜, "메모"
+                const matchDiv = line.match(/^(.*?),([\d.]+),(KRW|USD),(\d{4}-\d{2}-\d{2}),"(.*)"$/);
+                if (matchDiv) {
+                    const [, stockName, totalAmount, currency, paymentDate, note] = matchDiv;
+                    newDividends.push({
+                        id: Date.now().toString(36) + Math.random().toString(36).substr(2, 5),
+                        stockName: stockName.trim(),
+                        totalAmount: parseFloat(totalAmount),
+                        currency: currency.trim(),
+                        paymentDate: paymentDate.trim(),
+                        note: note.trim()
+                    });
+                }
+            }
+          }
+
+          if (newItems.length > 0 || newDividends.length > 0) {
+              items = newItems;
+              dividendRecords = newDividends;
+              updateAll();
+              alert(`불러오기 완료! (자산: ${newItems.length}개, 배당: ${newDividends.length}개)`);
+          } else {
+              alert('데이터를 찾을 수 없습니다.');
+          }
+
+        } catch (err) {
+          alert('CSV 형식이 올바르지 않습니다: ' + err.message);
+          console.error(err);
         }
       };
       reader.readAsText(file);
+      event.target.value = '';
     }
+
+    // 모달 배경 클릭 닫기 이벤트 연결
+    document.getElementById('dividendModal').addEventListener('click', function(e) {
+        if (e.target === this) closeDividendModal();
+    });
+    document.getElementById('stockModal').addEventListener('click', function(e) {
+        if (e.target === this) closeStockModal();
+    });
+    // 새 카테고리 Enter 키 입력 지원
+    document.getElementById('newCategoryInput').addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') { e.preventDefault(); addNewCategory(); }
+    });
 
     updateAll();
   </script>


### PR DESCRIPTION
## Summary

`stock-portfolio-dev` 저장소의 main 브랜치 내용을 production 환경에 반영합니다.
Firestore 경로를 `dev_users` → `users`로 변경한 것 외에 동일한 코드입니다.

## 변경사항

### 1. 종목 추가/수정 UI → 모달로 전환
- 기존 인라인 폼을 배당금 모달과 동일한 `.modal-overlay > .modal-content` 패턴으로 변경
- 추가 모드("📌 종목 추가")와 수정 모드("📌 종목 수정")를 동적으로 전환
- 날짜 필드를 date input으로 추가하여 사용자가 직접 선택/수정 가능
- 모달 배경 클릭 시 닫기 지원

### 2. 모달 입력 필드 라벨 추가
- 종목 모달: 종목 이름, 개수, 가격, 통화, 카테고리, 날짜
- 배당금 모달: 종목이름, 배당금액/통화, 지급일, 메모
- 수정 모드에서 각 필드가 어떤 정보인지 항상 표시되어 가독성 향상

### 3. 카테고리 입력 방식 개선
- 텍스트 입력(쉼표 구분) → **버튼 토글 선택** 방식으로 변경
- 기존 카테고리를 버튼으로 표시, 클릭으로 선택/해제
- 신규 카테고리 입력 + 추가 버튼 (Enter 키 지원)
- 신규 카테고리는 추가 즉시 선택 상태로 표시, ✕ 삭제 버튼 포함
- 기존 카테고리는 삭제 불가 (✕ 미표시)

### 4. 배당금 수정 기능 추가
- 배당금 목록 각 항목에 ✏️ 수정 버튼 추가 (삭제 버튼 왼쪽)
- 기존 모달을 수정 모드로 재활용 ("💰 배당금 수정" / "수정하기")

### 5. 다크모드 지원
- CSS Custom Properties 기반 테마 시스템 (25개+ CSS 변수)
- 헤더에 🌙/☀️ 토글 버튼, localStorage에 테마 저장/복원
- Chart.js 범례/제목/테두리 색상 테마 대응

### 6. 차트 데이터 내보내기
- Firebase 저장 차트 목록에서 개별 JSON/CSV 다운로드 버튼 추가
- CSV에 BOM 포함으로 한글 Excel 호환성 보장

### 7. CLAUDE.md 추가
- 프로젝트 개요, 기술 스택, 아키텍처, 데이터 모델, 개발 가이드라인 문서화

## 영향 범위
- `index.html` (+750, -200)
- `CLAUDE.md` (신규 생성)

## Test plan
- [ ] 종목 추가/수정 모달 정상 동작 확인
- [ ] 카테고리 버튼 토글 선택/해제, 신규 카테고리 추가/삭제 확인
- [ ] 배당금 추가/수정/삭제 정상 동작 확인
- [ ] 다크모드/라이트모드 전환 및 테마 저장 확인
- [ ] Firebase 저장/불러오기, JSON/CSV 내보내기 정상 동작 확인
- [ ] Firestore 경로가 `users`로 올바르게 설정되었는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)